### PR TITLE
Improve plugin UI layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Send to LLM Enhanced is a Burp Suite extension that integrates powerful AI analy
     Test different prompt templates interactively within the extension.
 
     💬 Custom Templates
-    Modify or add your own prompt formats via the "Config" tab.
+    Modify or add your own prompt formats via the "Config" tab. The configuration
+    screen now shows a list of templates beside an editable prompt area for easier
+    management, and the Pentester Tools tab displays prompts and responses in a split view.
 
 ## 📸 Screenshots
 


### PR DESCRIPTION
## Summary
- redesign Config tab with split template list & editor
- reorganize Pentester Tools panel with vertical split
- document the new design in README

## Testing
- `bash build.sh /dev/null /dev/null` *(fails: Provider not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ba9a7e94832b996a706610356d68